### PR TITLE
Improve search input debounce

### DIFF
--- a/specificities-overlap.js
+++ b/specificities-overlap.js
@@ -1,0 +1,36 @@
+var specificity = require('./specificity');
+
+function specificitiesOverlap(selector1, selector2, cache) {
+  var specificity1;
+  var specificity2;
+  var i, l;
+  var j, m;
+
+  for (i = 0, l = selector1.length; i < l; i++) {
+    specificity1 = findSpecificity(selector1[i][1], cache);
+
+    for (j = 0, m = selector2.length; j < m; j++) {
+      specificity2 = findSpecificity(selector2[j][1], cache);
+
+      if (specificity1[0] === specificity2[0]
+        && specificity1[1] === specificity2[1]
+        && specificity1[2] === specificity2[2]) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function findSpecificity(selector, cache) {
+  var value;
+
+  if (!(selector in cache)) {
+    cache[selector] = value = specificity(selector);
+  }
+
+  return value || cache[selector];
+}
+
+module.exports = specificitiesOverlap;


### PR DESCRIPTION
Add a 300ms debounce to the global search input to reduce redundant API calls and prevent UI flicker during rapid typing. The input handler is wrapped with lodash.debounce and unit tests updated to account for the delay.