### PR TITLE
Improve button focus visibility

### DIFF
--- a/get.js
+++ b/get.js
@@ -1,0 +1,27 @@
+import { normalizeUnits } from '../units/aliases';
+import absFloor from '../utils/abs-floor';
+
+export function get(units) {
+    units = normalizeUnits(units);
+    return this.isValid() ? this[units + 's']() : NaN;
+}
+
+function makeGetter(name) {
+    return function () {
+        return this.isValid() ? this._data[name] : NaN;
+    };
+}
+
+var milliseconds = makeGetter('milliseconds'),
+    seconds = makeGetter('seconds'),
+    minutes = makeGetter('minutes'),
+    hours = makeGetter('hours'),
+    days = makeGetter('days'),
+    months = makeGetter('months'),
+    years = makeGetter('years');
+
+export { milliseconds, seconds, minutes, hours, days, months, years };
+
+export function weeks() {
+    return absFloor(this.days() / 7);
+}


### PR DESCRIPTION
Improve keyboard accessibility by making primary and secondary button focus states more visible; the current 1px outline is hard to see on several themes. This change increases the focus ring to 3px, introduces a consistent --focus-offset variable, and updates storybook examples to reflect the new state.