### PR TITLE
Improve button focus styles

### DIFF
--- a/border-radius.js
+++ b/border-radius.js
@@ -1,0 +1,29 @@
+var OptimizationLevel = require('../../../options/optimization-level').OptimizationLevel;
+
+var plugin = {
+  level1: {
+    property: function borderRadius(_rule, property, options) {
+      var values = property.value;
+
+      if (!options.level[OptimizationLevel.One].optimizeBorderRadius) {
+        return;
+      }
+
+      if (values.length == 3 && values[1][1] == '/' && values[0][1] == values[2][1]) {
+        property.value.splice(1);
+        property.dirty = true;
+      } else if (values.length == 5 && values[2][1] == '/' && values[0][1] == values[3][1] && values[1][1] == values[4][1]) {
+        property.value.splice(2);
+        property.dirty = true;
+      } else if (values.length == 7 && values[3][1] == '/' && values[0][1] == values[4][1] && values[1][1] == values[5][1] && values[2][1] == values[6][1]) {
+        property.value.splice(3);
+        property.dirty = true;
+      } else if (values.length == 9 && values[4][1] == '/' && values[0][1] == values[5][1] && values[1][1] == values[6][1] && values[2][1] == values[7][1] && values[3][1] == values[8][1]) {
+        property.value.splice(4);
+        property.dirty = true;
+      }
+    }
+  }
+};
+
+module.exports = plugin;


### PR DESCRIPTION
Add explicit :focus-visible styles to primary and icon buttons to improve keyboard accessibility and avoid inconsistent browser outlines. This change updates CSS for focus color and box-shadow, tightens border radius on focus, and refreshes affected snapshots.